### PR TITLE
correct output pin for Digispark Pro

### DIFF
--- a/libraries/DigisparkTinyPpmGen/TinyPpmGen.cpp
+++ b/libraries/DigisparkTinyPpmGen/TinyPpmGen.cpp
@@ -9,7 +9,7 @@
    - Blocking fonctions such as delay() can be used in the loop() since it's an interrupt driven PPM generator
    - Supported devices: (The user has to define Timer and Channel to use in TinyPpmGen.h file of the library)
        - ATtiny167 (Digispark pro):
-         TIMER(0), CHANNEL(A) -> OC0A -> PB0 -> Pin#0
+         TIMER(0), CHANNEL(A) -> OC0A -> PA2 -> Pin#8
 
        - ATtiny85 (Digispark):
          TIMER(0), CHANNEL(A) -> OC0A -> PB0 -> Pin#0

--- a/libraries/DigisparkTinyPpmGen/TinyPpmGen.h
+++ b/libraries/DigisparkTinyPpmGen/TinyPpmGen.h
@@ -11,7 +11,7 @@
    - Blocking fonctions such as delay() can be used in the loop() since it's an interrupt driven PPM generator
    - Supported devices: (The user has to define Timer and Channel to use in TinyPpmGen.h file of the library)
        - ATtiny167 (Digispark pro):
-         TIMER(0), CHANNEL(A) -> OC0A -> PB0 -> Pin#0
+         TIMER(0), CHANNEL(A) -> OC0A -> PA2 -> Pin#8
 
        - ATtiny85 (Digispark):
          TIMER(0), CHANNEL(A) -> OC0A -> PB0 -> Pin#0

--- a/libraries/DigisparkTinyPpmGen/examples/RcPpmChSubst/RcPpmChSubst.ino
+++ b/libraries/DigisparkTinyPpmGen/examples/RcPpmChSubst/RcPpmChSubst.ino
@@ -8,7 +8,7 @@ The PPM input shall support pin change interrupt.
 PPM output pin is imposed by hardware and is target dependant:
 (The user has to define Timer and Channel to use in TinyPpmGen.h file of the library)
        - ATtiny167 (Digispark pro):
-         TIMER(0), CHANNEL(A) -> OC0A -> PB0 -> Pin#0
+         TIMER(0), CHANNEL(A) -> OC0A -> PA2 -> Pin#8
 
        - ATtiny85 (Digispark):
          TIMER(0), CHANNEL(A) -> OC0A -> PB0 -> Pin#0

--- a/libraries/DigisparkTinyPpmGen/examples/TinyPpmGenSweep/TinyPpmGenSweep.ino
+++ b/libraries/DigisparkTinyPpmGen/examples/TinyPpmGenSweep/TinyPpmGenSweep.ino
@@ -9,7 +9,7 @@ This sketch can work with a Digispark pro, Digispark and Arduino UNO.
 PPM output pin is imposed by hardware and is target dependant:
 (The user has to define Timer and Channel to use in TinyPpmGen.h file of the library)
        - ATtiny167 (Digispark pro):
-         TIMER(0), CHANNEL(A) -> OC0A -> PB0 -> Pin#0
+         TIMER(0), CHANNEL(A) -> OC0A -> PA2 -> Pin#8
 
        - ATtiny85 (Digispark):
          TIMER(0), CHANNEL(A) -> OC0A -> PB0 -> Pin#0


### PR DESCRIPTION
Digispark Pro uses output pin 8, not 0.  This was correct in one spot in TinyPpmGen.cpp and has been corrected elsewhere.
